### PR TITLE
Make it usable from typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ npm install akamai-edgeauth --save
 ## Example
 
 ```Javascript
-const EdgeAuth = require('akamai-edgeauth')
+const { EdgeAuth } = require('akamai-edgeauth')
 const http = require('http') // Module for the test
 
 

--- a/lib/edgeAuth.d.ts
+++ b/lib/edgeAuth.d.ts
@@ -1,0 +1,23 @@
+type Algorithm = "sha256" | "sha1" | "md5";
+type Options = {
+  tokenName?: string;
+  key: string;
+  algorithm?: Algorithm | Uppercase<Algorithm>;
+  salt?: string;
+  startTime?: number | "now";
+  endTime?: number;
+  windowSeconds?: number;
+  fieldDelimiter?: string;
+  aclDelimiter?: string;
+  escapeEarly?: boolean;
+  verbose?: boolean;
+};
+type HasDefaultKeys = "tokenName" | "algorithm" | "escapeEarly" | "fieldDelimiter" | "aclDelimiter" | "verbose";
+type InitializedOptions = Required<Pick<Options, HasDefaultKeys>> & Omit<Options, HasDefaultKeys>;
+
+export class EdgeAuth {
+  options: InitializedOptions;
+  constructor(options: Options);
+  generateACLToken(acl: string | string[]): string;
+  generateURLToken(url: string): string;
+}

--- a/lib/edgeAuth.js
+++ b/lib/edgeAuth.js
@@ -179,4 +179,4 @@ class EdgeAuth {
     }
 }
 
-module.exports = EdgeAuth
+module.exports = { EdgeAuth };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "akamai-edgeauth",
   "version": "0.2.0",
   "description": "Akamai Edge Authorization Token for Property Manager Behavior",
-  "main": "./lib/edgeauth.js",
+  "main": "./lib/edgeAuth.js",
   "scripts": {
     "test": "mocha --reporter spec --no-timeouts --ui bdd ./test/test-*"
   },

--- a/test/test-acl-edgeauth.js
+++ b/test/test-acl-edgeauth.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 const http = require('http')
 const fs = require('fs')
 const util = require('util')
-const EdgeAuth = require('../lib/edgeAuth')
+const { EdgeAuth } = require('../lib/edgeAuth')
 const expect = require('chai').expect
 
 const DEFAULT_WINDOW_SECOND = 10

--- a/test/test-url-edgeauth.js
+++ b/test/test-url-edgeauth.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 const http = require('http')
 const fs = require('fs')
 const util = require('util')
-const EdgeAuth = require('../lib/edgeauth')
+const { EdgeAuth } = require('../lib/edgeauth')
 const expect = require('chai').expect
 
 const DEFAULT_WINDOW_SECOND = 10


### PR DESCRIPTION
In TypeScript, it is not possible to import a module that exports a class by itself.
In other words, we are forced to use require, which does not allow us to define types.
Therefore, I changed the export method as follows, although it is a destructive change.

```javascript
// before
module.exports = EdgeAuth;

// after
module.exports = { EdgeAuth };
```

Then, I created a type definition file.

Now we can use from TypeScript as follows.

```typescript
import { EdgeAuth } from "akamai-edgeauth";
```