### PR TITLE
Update examples when sending Cookie in request

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ var token = ea.generateURLToken("/akamai/edgeauth")
 var options = {
     hostname: EA_HOSTNAME,
     path: '/akamai/edgeauth',
-    'Cookie': `${ea.options.tokenName}=${token}`
+    headers: {
+      Cookie: `${ea.options.tokenName}=${token}`
+    }
 }
 makeRequest(options, function(res) {
     console.log(res.statusCode) // If pass, it won't response 403 code.
@@ -119,7 +121,9 @@ var token = ea.generateURLToken(acl)
 var options = {
     hostname: EA_HOSTNAME,
     path: "/akamai/edgeauth/22",
-    Cookie: `${ea.options.tokenName}: ${token}`
+    headers: {
+      Cookie: `${ea.options.tokenName}=${token}`
+    }
 }
 makeRequest(options, function(res) {
     console.log(res.statusCode)


### PR DESCRIPTION
The request options in the Node examples are incorrect and do not result in the Cookie header being sent.  The examples are updated to use the correct options for request headers